### PR TITLE
✨ feat(series): implement Instagram-style grid and mosaic tile layouts

### DIFF
--- a/src/routes/2025/+page.server.ts
+++ b/src/routes/2025/+page.server.ts
@@ -8,13 +8,34 @@ export const load: PageServerLoad = () => {
 	const jsonContent = readFileSync(jsonPath, 'utf-8');
 	const indexData = JSON.parse(jsonContent);
 
-	// シリーズ一覧用に軽量化（title, slug, tweetCount, styleのみ）
-	const lightSeries = indexData.series.map((s: any) => ({
-		title: s.title,
-		slug: s.slug,
-		tweetCount: s.tweetCount,
-		style: s.style
-	}));
+	// シリーズ一覧用に軽量化（サムネイル付き）
+	const lightSeries = indexData.series.map((s: any) => {
+		let thumbnailUrl: string | undefined;
+		let thumbnailType: 'photo' | 'video' | undefined;
+
+		for (const tweet of s.tweets) {
+			if (tweet.entities?.media && tweet.entities.media.length > 0) {
+				const media = tweet.entities.media[0];
+				if (media.type === 'photo') {
+					thumbnailUrl = media.media_url_https;
+					thumbnailType = 'photo';
+					break;
+				} else if (media.type === 'video' || media.type === 'animated_gif') {
+					thumbnailUrl = media.media_url_https;
+					thumbnailType = 'video';
+				}
+			}
+		}
+
+		return {
+			title: s.title,
+			slug: s.slug,
+			tweetCount: s.tweetCount,
+			style: s.style,
+			thumbnailUrl,
+			thumbnailType
+		};
+	});
 
 	return {
 		tweetsByMonth: indexData.tweetsByMonth,

--- a/src/routes/2025/+page.svelte
+++ b/src/routes/2025/+page.svelte
@@ -17,12 +17,45 @@
 		title: string;
 		slug: string;
 		tweetCount: number;
+		thumbnailUrl?: string;
+		thumbnailType?: 'photo' | 'video';
+		style?: string;
 	}
 
 	const tweetsByMonth: MonthlyLog[] = data.tweetsByMonth;
 	const series: Series[] = data.series;
 	const totalTweets = data.totalTweets;
 	const totalSeries = data.totalSeries;
+
+	// スタイルに応じた色
+	const styleColors: Record<string, string> = {
+		circle: '#00f0ff',
+		solid_circle: '#d4af37',
+		keycap: '#ff6b6b',
+		standard: '#4ecdc4',
+		vol: '#a8e6cf'
+	};
+
+	// ランダムな薄いグラデーションを生成（slugに基づいて決定論的）
+	const gradients = [
+		'linear-gradient(135deg, rgba(0, 240, 255, 0.08), rgba(78, 205, 196, 0.05))',
+		'linear-gradient(135deg, rgba(212, 175, 55, 0.08), rgba(255, 107, 107, 0.05))',
+		'linear-gradient(135deg, rgba(168, 230, 207, 0.08), rgba(0, 240, 255, 0.05))',
+		'linear-gradient(135deg, rgba(255, 107, 107, 0.08), rgba(212, 175, 55, 0.05))',
+		'linear-gradient(135deg, rgba(78, 205, 196, 0.08), rgba(168, 230, 207, 0.05))',
+		'linear-gradient(135deg, rgba(147, 112, 219, 0.08), rgba(0, 240, 255, 0.05))',
+		'linear-gradient(135deg, rgba(255, 154, 162, 0.08), rgba(250, 208, 196, 0.05))',
+		'linear-gradient(135deg, rgba(116, 185, 255, 0.08), rgba(162, 155, 254, 0.05))'
+	];
+
+	function getGradient(slug: string): string {
+		let hash = 0;
+		for (let i = 0; i < slug.length; i++) {
+			hash = ((hash << 5) - hash) + slug.charCodeAt(i);
+			hash = hash & hash;
+		}
+		return gradients[Math.abs(hash) % gradients.length];
+	}
 
 	onMount(() => {
 		// Intersection Observer for scroll animations
@@ -100,11 +133,23 @@
 		<div class="section-title"><i class="fa-solid fa-layer-group"></i> Series Collection</div>
 		<div class="section-desc">Curated threads and topic series</div>
 	</div>
-	<div class="series-list">
+	<div class="insta-grid">
 		{#each series as s}
-			<a href="{base}/2025/series/{s.slug}" class="series-card">
-				<div class="series-title">{s.title}</div>
-				<div class="series-count">{s.tweetCount} tweets</div>
+			<a
+				href="{base}/2025/series/{s.slug}"
+				class="insta-tile"
+				class:has-image={s.thumbnailUrl}
+				style="--tile-gradient: {getGradient(s.slug)}">
+				{#if s.thumbnailUrl}
+					<img src={s.thumbnailUrl} alt={s.title} class="insta-image" loading="lazy" />
+				{/if}
+				<div class="insta-overlay">
+					<div class="insta-title">{s.title}</div>
+					<div class="insta-meta">
+						<span class="insta-style" style:color={s.style ? styleColors[s.style] : undefined}>{s.style || ''}</span>
+						<span class="insta-count">{s.tweetCount} tweets</span>
+					</div>
+				</div>
 			</a>
 		{/each}
 	</div>
@@ -244,41 +289,99 @@
 		color: #888;
 	}
 
-	/* Series List */
-	.series-list {
-		display: flex;
-		flex-direction: column;
-		gap: 15px;
+	/* Instagram Grid */
+	.insta-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: 4px;
 	}
 
-	.series-card {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		background: rgba(212, 175, 55, 0.05);
-		border: 1px solid rgba(212, 175, 55, 0.2);
-		border-radius: 8px;
-		padding: 15px 20px;
+	.insta-tile {
+		position: relative;
+		display: block;
+		aspect-ratio: 1;
 		text-decoration: none;
 		color: inherit;
-		transition: all 0.3s ease;
+		background: #1a1a1a;
+		overflow: hidden;
+		transition: transform 0.3s ease;
 	}
 
-	.series-card:hover {
-		background: rgba(212, 175, 55, 0.1);
-		transform: translateX(10px);
-		box-shadow: 0 5px 20px rgba(212, 175, 55, 0.2);
+	.insta-tile:hover {
+		transform: scale(1.02);
+		z-index: 1;
 	}
 
-	.series-title {
-		font-size: 1rem;
-		color: #e0e0e0;
+	.insta-tile:not(.has-image) {
+		background: var(--tile-gradient);
+		border: 1px solid rgba(255, 255, 255, 0.05);
 	}
 
-	.series-count {
+	.insta-image {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.insta-overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.85));
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		padding: 16px;
+		opacity: 0;
+		transition: opacity 0.3s ease;
+	}
+
+	.insta-tile:not(.has-image) .insta-overlay {
+		opacity: 1;
+	}
+
+	.insta-tile:hover .insta-overlay {
+		opacity: 1;
+	}
+
+	.insta-title {
+		font-family: 'Noto Serif JP', serif;
+		font-size: 0.95rem;
+		font-weight: 500;
+		color: #fff;
+		text-align: center;
+		line-height: 1.4;
+		margin-bottom: 10px;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.insta-meta {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 6px;
+		font-size: 0.75rem;
+	}
+
+	.insta-style {
 		font-family: 'Orbitron', sans-serif;
-		font-size: 0.8rem;
-		color: #d4af37;
+		text-transform: uppercase;
+		letter-spacing: 0.1rem;
+		background: rgba(255, 255, 255, 0.15);
+		padding: 3px 8px;
+		border-radius: 3px;
+	}
+
+	.insta-count {
+		font-family: 'Orbitron', sans-serif;
+		color: #888;
 	}
 
 	@media (max-width: 768px) {

--- a/src/routes/2025/series/+page.server.ts
+++ b/src/routes/2025/series/+page.server.ts
@@ -3,18 +3,41 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 export const load: PageServerLoad = () => {
-	// index.jsonから軽量なシリーズデータのみ読み込み
+	// index.jsonからシリーズデータを読み込み
 	const jsonPath = join(process.cwd(), 'static/data/index.json');
 	const jsonContent = readFileSync(jsonPath, 'utf-8');
 	const indexData = JSON.parse(jsonContent);
 
-	// シリーズ一覧用に軽量化（title, slug, tweetCount, styleのみ）
-	const series = indexData.series.map((s: any) => ({
-		title: s.title,
-		slug: s.slug,
-		tweetCount: s.tweetCount,
-		style: s.style
-	}));
+	// 各シリーズの代表画像を抽出
+	const series = indexData.series.map((s: any) => {
+		// 最初の画像付きツイートを探す
+		let thumbnailUrl: string | undefined;
+		let thumbnailType: 'photo' | 'video' | undefined;
+
+		for (const tweet of s.tweets) {
+			if (tweet.entities?.media && tweet.entities.media.length > 0) {
+				const media = tweet.entities.media[0];
+				if (media.type === 'photo') {
+					thumbnailUrl = media.media_url_https;
+					thumbnailType = 'photo';
+					break;
+				} else if (media.type === 'video' || media.type === 'animated_gif') {
+					thumbnailUrl = media.media_url_https;
+					thumbnailType = 'video';
+					// 画像が見つかるまで続ける
+				}
+			}
+		}
+
+		return {
+			title: s.title,
+			slug: s.slug,
+			tweetCount: s.tweetCount,
+			style: s.style,
+			thumbnailUrl,
+			thumbnailType
+		};
+	});
 
 	return {
 		series

--- a/src/routes/2025/series/+page.svelte
+++ b/src/routes/2025/series/+page.svelte
@@ -19,6 +19,15 @@
 			window.scrollBy({ top: 100, behavior: 'smooth' });
 		}, 100);
 	}
+
+	// スタイルに応じた色
+	const styleColors: Record<string, string> = {
+		circle: '#00f0ff',
+		solid_circle: '#d4af37',
+		keycap: '#ff6b6b',
+		standard: '#4ecdc4',
+		vol: '#a8e6cf'
+	};
 </script>
 
 <svelte:head>
@@ -42,17 +51,33 @@
 	</header>
 
 	<main>
-		<div class="series-list">
+		<div class="mosaic-grid">
 			{#each visibleSeries() as s (s.slug)}
-				<a href="{base}/2025/series/{s.slug}" class="series-card">
-					<div class="series-info">
-						<div class="series-title">{s.title}</div>
-						<div class="series-meta">
-							<span class="series-style">{s.style}</span>
-							<span class="series-count">{s.tweetCount} tweets</span>
+				<a href="{base}/2025/series/{s.slug}" class="mosaic-tile" class:has-image={s.thumbnailUrl}>
+					{#if s.thumbnailUrl}
+						<div class="tile-image-wrapper">
+							<img
+								src={s.thumbnailUrl}
+								alt={s.title}
+								class="tile-image"
+								loading="lazy" />
+							{#if s.thumbnailType === 'video'}
+								<div class="video-indicator">
+									<i class="fa-solid fa-play"></i>
+								</div>
+							{/if}
 						</div>
+					{/if}
+					<div class="tile-content">
+						<div class="tile-style" style="color: {styleColors[s.style] || '#888'}">
+							{s.style}
+						</div>
+						<div class="tile-title">{s.title}</div>
+						<div class="tile-count">{s.tweetCount} tweets</div>
 					</div>
-					<div class="series-arrow"><i class="fa-solid fa-chevron-right"></i></div>
+					<div class="tile-overlay">
+						<i class="fa-solid fa-arrow-right overlay-icon"></i>
+					</div>
 				</a>
 			{/each}
 		</div>
@@ -83,7 +108,7 @@
 	.container {
 		min-height: 100vh;
 		padding: 40px 20px 80px;
-		max-width: 1000px;
+		max-width: 1400px;
 		margin: 0 auto;
 		position: relative;
 		z-index: 1;
@@ -93,10 +118,10 @@
 	.breadcrumbs {
 		display: flex;
 		align-items: center;
-		gap: 10px;
+		gap: 8px;
 		flex-wrap: wrap;
-		margin-bottom: 30px;
-		font-size: 0.9rem;
+		margin-bottom: 40px;
+		font-size: 0.85rem;
 		font-family: 'Orbitron', sans-serif;
 		padding: 12px 20px;
 		background: rgba(0, 0, 0, 0.3);
@@ -118,13 +143,9 @@
 		text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
 	}
 
-	.breadcrumbs span {
-		color: #888;
-	}
-
 	.breadcrumbs .separator {
-		color: #888;
-		font-size: 0.7rem;
+		color: #666;
+		font-size: 0.65rem;
 	}
 
 	.breadcrumbs .current {
@@ -154,7 +175,7 @@
 		font-family: 'Orbitron', sans-serif;
 		font-size: 3rem;
 		color: #e0e0e0;
-		margin-bottom: 10px;
+		margin-bottom: 15px;
 	}
 
 	.subtitle {
@@ -167,64 +188,157 @@
 		display: inline-block;
 	}
 
-	/* Series List */
-	.series-list {
-		display: flex;
-		flex-direction: column;
-		gap: 15px;
+	/* Mosaic Grid Layout */
+	.mosaic-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: 20px;
 	}
 
-	.series-card {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		background: rgba(212, 175, 55, 0.05);
-		border: 1px solid rgba(212, 175, 55, 0.2);
-		border-radius: 8px;
-		padding: 15px 20px;
+	/* Mosaic Tile */
+	.mosaic-tile {
+		position: relative;
+		display: block;
 		text-decoration: none;
 		color: inherit;
-		transition: all 0.3s ease;
+		background: rgba(20, 20, 25, 0.6);
+		border: 1px solid rgba(212, 175, 55, 0.2);
+		border-radius: 16px;
+		overflow: hidden;
+		transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+		backdrop-filter: blur(10px);
+		box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+		min-height: 200px;
 	}
 
-	.series-card:hover {
-		background: rgba(212, 175, 55, 0.1);
-		transform: translateX(10px);
-		box-shadow: 0 5px 20px rgba(212, 175, 55, 0.2);
+	.mosaic-tile:hover {
+		transform: translateY(-8px) scale(1.02);
+		border-color: rgba(0, 240, 255, 0.5);
+		box-shadow: 0 20px 50px rgba(0, 240, 255, 0.3);
 	}
 
-	.series-info {
-		flex: 1;
+	.mosaic-tile:not(.has-image) {
+		background: linear-gradient(145deg, rgba(20, 20, 25, 0.9), rgba(10, 10, 15, 0.95));
+		border: 2px solid rgba(212, 175, 55, 0.3);
 	}
 
-	.series-title {
-		font-size: 1rem;
-		color: #e0e0e0;
-		margin-bottom: 5px;
+	/* Tile Image */
+	.tile-image-wrapper {
+		width: 100%;
+		height: 200px;
+		overflow: hidden;
+		position: relative;
+		background: #000;
 	}
 
-	.series-meta {
+	.tile-image {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		transition: transform 0.6s ease;
+		display: block;
+	}
+
+	.mosaic-tile:hover .tile-image {
+		transform: scale(1.1);
+	}
+
+	.video-indicator {
+		position: absolute;
+		top: 10px;
+		right: 10px;
+		width: 32px;
+		height: 32px;
+		background: rgba(0, 0, 0, 0.7);
+		border-radius: 50%;
 		display: flex;
-		gap: 15px;
+		align-items: center;
+		justify-content: center;
+		backdrop-filter: blur(5px);
+	}
+
+	.video-indicator i {
+		color: #fff;
+		font-size: 0.9rem;
+	}
+
+	/* Tile Content */
+	.tile-content {
+		padding: 16px;
+		position: relative;
+		z-index: 1;
+		background: linear-gradient(to top, rgba(5, 5, 5, 0.95), rgba(5, 5, 5, 0.7));
+		backdrop-filter: blur(10px);
+		border-top: 1px solid rgba(212, 175, 55, 0.1);
+	}
+
+	.has-image .tile-content {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		padding: 16px;
+		background: linear-gradient(to top, rgba(0, 0, 0, 0.95), rgba(0, 0, 0, 0.6));
+	}
+
+	.tile-style {
+		font-family: 'Orbitron', sans-serif;
+		font-size: 0.65rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1rem;
+		padding: 4px 10px;
+		background: rgba(255, 255, 255, 0.1);
+		border-radius: 4px;
+		display: inline-block;
+		margin-bottom: 8px;
+	}
+
+	.tile-title {
+		font-family: 'Noto Serif JP', serif;
+		font-size: 1rem;
+		font-weight: 500;
+		color: #e0e0e0;
+		line-height: 1.4;
+		margin-bottom: 8px;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.tile-count {
+		font-family: 'Orbitron', sans-serif;
 		font-size: 0.8rem;
 		color: #888;
 	}
 
-	.series-style {
-		font-family: 'Orbitron', sans-serif;
-		padding: 2px 8px;
-		background: rgba(212, 175, 55, 0.1);
-		border-radius: 4px;
-		text-transform: uppercase;
+	/* Overlay Icon */
+	.tile-overlay {
+		position: absolute;
+		top: 15px;
+		right: 15px;
+		width: 36px;
+		height: 36px;
+		background: rgba(0, 0, 0, 0.6);
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		transform: scale(0.8);
+		transition: all 0.3s ease;
+		backdrop-filter: blur(5px);
+		z-index: 2;
 	}
 
-	.series-count {
-		color: #d4af37;
+	.mosaic-tile:hover .tile-overlay {
+		opacity: 1;
+		transform: scale(1);
 	}
 
-	.series-arrow {
-		font-size: 1.2rem;
-		color: #d4af37;
+	.overlay-icon {
+		color: #00f0ff;
+		font-size: 1rem;
 	}
 
 	/* Load More Button */
@@ -246,7 +360,7 @@
 		font-family: 'Orbitron', sans-serif;
 		font-size: 1rem;
 		font-weight: 600;
-		letter-spacing: 0.1rem;
+			letter-spacing: 0.1rem;
 		cursor: pointer;
 		transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 		backdrop-filter: blur(10px);
@@ -326,6 +440,15 @@
 	@media (max-width: 768px) {
 		.main-title {
 			font-size: 2rem;
+		}
+
+		.mosaic-grid {
+			grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+			gap: 15px;
+		}
+
+		.tile-image-wrapper {
+			height: 150px;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

Replace the traditional card-based series list layout with modern visual grid layouts:

- **2025 top page**: Instagram-style square grid with thumbnail images
- **Series index page**: Mosaic tile layout with hover effects

Both pages now display thumbnail images extracted from tweet media, creating a more visually appealing browsing experience.

## Changes

### Server-side Changes
- `+page.server.ts`: Add thumbnail extraction logic (photo prioritized over video)
- `series/+page.server.ts`: Add thumbnail extraction logic

### Client-side Changes
- `+page.svelte`: Instagram-style grid layout with overlay on hover
- `series/+page.svelte`: Mosaic tile layout with video indicators

### New Features
- Thumbnail images with lazy loading
- Gradient backgrounds for series without images
- Style color mapping (circle, solid_circle, keycap, standard, vol)
- Hover effects with scale and overlay transitions
- Video indicator badges for video/GIF content

## Test plan

- [x] Build succeeds without errors
- [x] Series display with thumbnail images
- [x] Hover effects work correctly
- [x] Series without images show gradient backgrounds
- [x] Video indicators appear for video/GIF content

## Build & Test Results

**Build**: ✅ Success
```
vite v6.4.1 building SSR bundle for production
✅ Preprocessing complete
✅ Build complete
```

**Files changed**: 4 files (+369, -99)

## Multifaceted Analysis

### Technical Perspective
- Thumbnail extraction uses existing tweet data from index.json
- Lazy loading implemented for performance
- CSS Grid with responsive breakpoints
- Aspect ratio maintained for square tiles

### Operational Perspective
- No API changes required
- Uses existing data structure
- Minimal performance impact (thumbnails from existing data)

### User Perspective
- More visually appealing series discovery
- Easier to identify content at a glance
- Instagram-like familiar UX
- Better mobile experience with responsive grid

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)